### PR TITLE
Improve stability

### DIFF
--- a/.cyclid.json
+++ b/.cyclid.json
@@ -1,0 +1,125 @@
+{
+   "name" : "Cyclid-lxd-plugin",
+   "environment":
+      {
+        "os": "ubuntu_trusty",
+        "repos": [
+          {
+            "url": "ppa:brightbox/ruby-ng"
+          }
+        ],
+        "packages": [
+          "ruby2.3",
+          "ruby2.3-dev",
+          "build-essential",
+          "git",
+          "zlib1g-dev",
+          "libsqlite3-dev",
+          "mysql-client",
+          "libmysqlclient-dev"
+        ]
+      },
+   "sources": [
+      {
+        "type": "git",
+        "url": "https://github.com/Cyclid/Cyclid-lxd-plugin"
+      },
+      {
+        "type": "git",
+        "url": "https://github.com/Cyclid/Cyclid"
+      },
+      {
+        "type": "git",
+        "url": "https://github.com/Cyclid/Cyclid-core"
+      }
+   ],
+   "stages" : [
+      {
+        "name" : "bundle-install",
+        "steps" : [
+          {
+            "action" : "command", 
+            "cmd" : "sudo gem install bundler --no-ri --no-doc"
+          },
+          {
+            "action" : "command",
+            "cmd": "bundle install --path vendor/bundle",
+            "path" : "%{workspace}/Cyclid-lxd-plugin"
+          }
+        ]
+      },
+      {
+        "name" : "lint",
+        "steps" : [
+          {
+            "action" : "command",
+            "cmd" : "bundle exec rake rubocop",
+            "path" : "%{workspace}/Cyclid-lxd-plugin"
+          }
+        ]
+      },
+      {
+        "name": "rspec",
+        "steps": [
+          {
+            "action" : "command",
+            "cmd" : "bundle exec rake spec",
+            "path" : "%{workspace}/Cyclid-lxd-plugin"
+          }
+        ]
+      },
+      {
+        "name": "build",
+        "steps": [
+          {
+            "action" : "command",
+            "cmd" : "bundle exec rake build",
+            "path" : "%{workspace}/Cyclid-lxd-plugin"
+          }
+        ]
+      },
+      {
+        "name": "success",
+        "steps": [
+          {
+            "action" : "slack",
+            "subject" : "%{job_name} succeeded",
+            "message" : "Build %{organization}/%{job_name} (job #%{job_id}) completed successfully."
+          }
+        ]
+      },
+      {
+        "name": "failure",
+        "steps": [
+          {
+            "action" : "slack",
+            "subject" : "%{job_name} failed",
+            "message" : "Build %{organization}/%{job_name} (job #%{job_id}) failed.",
+            "color" : "danger"
+          }
+        ]
+      }
+   ],
+   "sequence" : [
+      {
+         "stage" : "bundle-install",
+         "on_success" : "lint",
+         "on_failure" : "failure"
+      },
+      {
+        "stage" : "lint",
+        "on_success" : "rspec",
+        "on_failure" : "failure"
+      },
+      {
+        "stage" : "rspec",
+        "on_success" : "build",
+        "on_failure" : "failure"
+      },
+      {
+        "stage" : "build",
+        "on_success" : "success",
+        "on_failure" : "failure"
+      }
+   ]
+}

--- a/Gemfile
+++ b/Gemfile
@@ -3,16 +3,14 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'hyperkit', git: 'git@github.com:Cyclid/hyperkit.git', branch: 'vanders/exec_capture'
-
 group :development, :test do
   gem 'rake'
-  gem 'rubocop'
   gem 'rspec'
-  gem 'simplecov'
-  gem 'yard'
-  gem 'webmock'
+  gem 'rubocop'
   gem 'rubygems-tasks'
+  gem 'simplecov'
+  gem 'webmock'
+  gem 'yard'
 
   gem 'cyclid', path: '../Cyclid'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: git@github.com:Cyclid/hyperkit.git
-  revision: 108c419daf98f5da76c12b8a29c739aeb15167d8
-  branch: vanders/exec_capture
-  specs:
-    hyperkit (1.0.2)
-      activesupport (~> 4.2.6)
-      sawyer
-
 PATH
   remote: ../Cyclid
   specs:
@@ -20,7 +11,6 @@ PATH
       google-api-client (~> 0.8.6)
       jwt (~> 1.5)
       mail (~> 2.6)
-      mysql (~> 2.9)
       net-scp (~> 1.2)
       net-ssh (~> 3.1)
       nokogiri (~> 1.6)
@@ -42,7 +32,7 @@ PATH
   specs:
     cyclid-lxd-plugin (0.1.0)
       cyclid (~> 0.2)
-      hyperkit (~> 1.0)
+      hyperkit (~> 1.1)
       websocket-client-simple (~> 0.3.0)
 
 GEM
@@ -71,11 +61,11 @@ GEM
     backports (3.6.8)
     bcrypt (3.1.11)
     builder (3.2.2)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.3)
     connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    css_parser (1.4.6)
+    css_parser (1.4.7)
       addressable
     cyclid-core (0.1.1)
       rack (~> 1.6)
@@ -122,6 +112,9 @@ GEM
       signet (~> 0.7)
     hashdiff (0.3.1)
     htmlentities (4.3.4)
+    hyperkit (1.1.0)
+      activesupport (~> 4.2.6)
+      sawyer
     i18n (0.7.0)
     json (1.8.3)
     jwt (1.5.6)
@@ -138,10 +131,9 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.9.1)
+    minitest (5.10.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    mysql (2.9.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
@@ -149,9 +141,9 @@ GEM
       mini_portile2 (~> 2.1.0)
     octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (2.17.5)
+    oj (2.18.0)
     os (0.9.6)
-    parser (2.3.2.0)
+    parser (2.3.3.1)
       ast (~> 2.2)
     powerpack (0.1.1)
     premailer (1.8.7)
@@ -163,7 +155,7 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     rainbow (2.1.0)
-    rake (11.3.0)
+    rake (12.0.0)
     redis (3.3.2)
     require_all (1.3.3)
     retriable (1.4.1)
@@ -180,7 +172,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.45.0)
+    rubocop (0.46.0)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
@@ -192,7 +184,7 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
-    sidekiq (4.2.6)
+    sidekiq (4.2.7)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
@@ -228,10 +220,10 @@ GEM
     tilt (2.0.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    unicode-display_width (1.1.1)
+    unicode-display_width (1.1.2)
     warden (1.2.6)
       rack (>= 1.0)
-    webmock (2.1.0)
+    webmock (2.3.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -247,7 +239,6 @@ PLATFORMS
 DEPENDENCIES
   cyclid!
   cyclid-lxd-plugin!
-  hyperkit!
   rake
   rspec
   rubocop

--- a/cyclid-lxd-plugin.gemspec
+++ b/cyclid-lxd-plugin.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email       = 'contact@cyclid.io'
   s.files       = Dir.glob('lib/**/*')
 
-  s.add_runtime_dependency('hyperkit', '~> 1.0')
+  s.add_runtime_dependency('hyperkit', '~> 1.1')
   s.add_runtime_dependency('websocket-client-simple', '~> 0.3.0')
 
   s.add_runtime_dependency('cyclid', '~> 0.2')


### PR DESCRIPTION
Depend on Hyperkit 1.1, which is complete with the changes this plugin
requires.
Correctly handle text from the exec WebSocket, so as not to attempt to
inject invalid UTF-8 byte sequences into the log.
Have the transport decide if 'sudo' should be prepended.